### PR TITLE
Use generated_name for deployments

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "project_name": "",
     "project_slug": "{{ cookiecutter.project_name|lower|replace(' ', '')|replace('-', '_') }}",
-    "project_dash_slug": "{{ cookiecutter.project_slug|replace('_', '-') }}",
+    "project_generated_name": "",
     "custom_domain": "",
     "repo_url": "",
     "heroku_dyno_size": "",

--- a/{{cookiecutter.project_slug}}/variables.tf
+++ b/{{cookiecutter.project_slug}}/variables.tf
@@ -1,7 +1,7 @@
 variable "app_name" {
   description = "Unique name of the app"
   type = "string"
-  default = "{{cookiecutter.project_slug}}"
+  default = "{{cookiecutter.project_generated_name}}"
 }
 
 variable "custom_domain" {


### PR DESCRIPTION
This removes the unused var `project_dash_slug`, adds `project_generated_name` (the project name with dashes), and uses it for the Heroku app name to match previous deployment settings.