### PR TITLE
Fix reset password API

### DIFF
--- a/{{cookiecutter.project_slug}}/home/api/v1/serializers.py
+++ b/{{cookiecutter.project_slug}}/home/api/v1/serializers.py
@@ -2,10 +2,12 @@ from django.contrib.auth import get_user_model
 from django.http import HttpRequest
 from django.utils.translation import ugettext_lazy as _
 from allauth.account import app_settings as allauth_settings
+from allauth.account.forms import ResetPasswordForm
 from allauth.utils import email_address_exists, generate_unique_username
 from allauth.account.adapter import get_adapter
 from allauth.account.utils import setup_user_email
 from rest_framework import serializers
+from rest_auth.serializers import PasswordResetSerializer
 
 from home.models import CustomText, HomePage
 
@@ -80,3 +82,8 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ['id', 'email', 'name']
+
+
+class PasswordSerializer(PasswordResetSerializer):
+    """Custom serializer for rest_auth to solve reset password error"""
+    password_reset_form_class = ResetPasswordForm

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
@@ -172,6 +172,10 @@ SOCIALACCOUNT_ADAPTER = "users.adapters.SocialAccountAdapter"
 ACCOUNT_ALLOW_REGISTRATION = env.bool("ACCOUNT_ALLOW_REGISTRATION", True)
 SOCIALACCOUNT_ALLOW_REGISTRATION = env.bool("SOCIALACCOUNT_ALLOW_REGISTRATION", True)
 
+REST_AUTH_SERIALIZERS = {
+    # Replace password reset serializer to fix 500 error
+    "PASSWORD_RESET_SERIALIZER": "home.api.v1.serializers.PasswordSerializer",
+}
 REST_AUTH_REGISTER_SERIALIZERS = {
     # Use custom serializer that has no username and matches web signup
     "REGISTER_SERIALIZER": "home.api.v1.serializers.SignupSerializer",


### PR DESCRIPTION
The rest_auth reset password serializer uses Django's form. This doesn't work when using allauth. This PR replaces the form with allauth's reset password form.

Solution taken from https://stackoverflow.com/questions/26869309/django-rest-framework-django-allauth-password-reset-recovery/36365644#36365644

This one led me down a bit of a rabbit hole. To ensure this was the best fix I ended up looking at two rest_auth Github issues, two StackOverflow posts, the rest_auth source, and Django’s source.