### PR TITLE
Add system libs for pillow

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -10,7 +10,11 @@ RUN apk add --no-cache --update \
   python3 \
   python3-dev \
   py3-pip \
-  curl
+  curl \
+# zlib, zlib-dev, and libjpeg are required by pillow
+  zlib \
+  zlib-dev \
+  libjpeg
 RUN pip3 install --no-cache-dir -q pipenv
 
 # Add our code


### PR DESCRIPTION
Pillow is used frequently enough that including its required system libs by default makes sense. They may also be used by other packages.