### PR TITLE
Add swagger api docs to the scaffold

### DIFF
--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -19,6 +19,7 @@ django-bootstrap4 = "~=0.0.8"
 django-allauth = "~=0.39.1"
 django-rest-auth = "~=0.9.5"
 django-extensions = "~=2.1.9"
+drf-yasg = "~=1.16.1"
 {% if cookiecutter.is_mobile == "y" %}
 fcm-django = "~=0.2.21"
 {% endif %}

--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -19,6 +19,7 @@ django-bootstrap4 = "~=0.0.8"
 django-allauth = "~=0.39.1"
 django-rest-auth = "~=0.9.5"
 django-extensions = "~=2.1.9"
+packaging = "*"
 drf-yasg = "~=1.16.1"
 {% if cookiecutter.is_mobile == "y" %}
 fcm-django = "~=0.2.21"

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
@@ -61,6 +61,7 @@ THIRD_PARTY_APPS = [
     'allauth.socialaccount',
     'allauth.socialaccount.providers.google',
     'django_extensions',
+    'drf_yasg',
 {% if cookiecutter.is_mobile == "y" %}
     # start fcm_django push notifications
     'fcm_django',
@@ -203,6 +204,10 @@ FCM_DJANGO_SETTINGS = {
 }
 # end fcm_django push notifications
 {% endif %}
+
+# swagger config
+# LOGIN_URL = "account_login"
+# LOGOUT_URL = "account_logout"
 
 if DEBUG:
     # output email to console instead of sending

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
@@ -205,10 +205,6 @@ FCM_DJANGO_SETTINGS = {
 # end fcm_django push notifications
 {% endif %}
 
-# swagger config
-# LOGIN_URL = "account_login"
-# LOGOUT_URL = "account_logout"
-
 if DEBUG:
     # output email to console instead of sending
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/urls.py
@@ -16,6 +16,9 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from allauth.account.views import confirm_email
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 
 urlpatterns = [
     path('', include('home.urls')),
@@ -32,3 +35,18 @@ urlpatterns = [
 admin.site.site_header = '{{cookiecutter.project_name}}'
 admin.site.site_title = '{{cookiecutter.project_name}} Admin Portal'
 admin.site.index_title = '{{cookiecutter.project_name}} Admin'
+
+# swagger
+schema_view = get_schema_view(
+    openapi.Info(
+        title="{{cookiecutter.project_name}} API",
+        default_version="v1",
+        description="API documentation for {{cookiecutter.project_name}} App",
+    ),
+    public=True,
+    permission_classes=(permissions.IsAuthenticated,),
+)
+
+urlpatterns += [
+    path("api-docs/", schema_view.with_ui("swagger", cache_timeout=0), name="api_docs")
+]


### PR DESCRIPTION
This PR adds swagger docs generation through the package `drf_yasg`.

The url for the web version of the docs is `/api-docs` and requires the user to be authenticated