### PR TITLE
Update Heroku Terraform provider to 2.2.1

### DIFF
--- a/{{cookiecutter.project_slug}}/main.tf
+++ b/{{cookiecutter.project_slug}}/main.tf
@@ -1,5 +1,5 @@
 provider "heroku" {
-  version = "~> 1.5"
+  version = "~> 2.2.1"
 }
 provider "cloudflare" {
   version = "~> 1.9"


### PR DESCRIPTION
This upgrades the Heroku provider to the latest version. There shouldn't be any breaking changes. This is needed up upgrade Terraform to the latest version.