### PR TITLE
Add variable for secret key

### DIFF
--- a/{{cookiecutter.project_slug}}/env_prod.tf
+++ b/{{cookiecutter.project_slug}}/env_prod.tf
@@ -8,6 +8,9 @@ resource "heroku_app" "production" {
     locked = "false"
     personal = "false"
   }
+  sensitive_config_vars = {
+    SECRET_KEY = "${var.heroku_secret_key}"
+  }
 }
 
 resource "heroku_addon" "database_production" {

--- a/{{cookiecutter.project_slug}}/variables.tf
+++ b/{{cookiecutter.project_slug}}/variables.tf
@@ -27,3 +27,9 @@ variable "heroku_team" {
   type = "string"
   default = "{{cookiecutter.heroku_team}}"
 }
+
+variable "heroku_secret_key" {
+  description = "SECRET_KEY env var for the Heroku app. OVERRIDE, DO NOT USE THE DEFAULT."
+  type = "string"
+  default = "change_me_123"
+}


### PR DESCRIPTION
This allows us to pass in the secret key. Doing so will fix the first deploy failing and allow us to deploy once instead of twice.

To work properly this requires some changes to crowdbotics-slack. It's safe to merge this first. Until that's updated on first deploy it will use the default value but that will be overridden once Terraform is complete.