### PR TITLE
Pin python 3.7.5 and alpine 3.10

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:latest
+FROM alpine:3.10
 
 # Add the testing repo in case it's needed for additional dependencies
-# For example, gdal can be installed by using gdal@testing
-RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+# For example, gdal can be installed by using gdal@community
+RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 
 # Install system dependencies
 RUN apk add --no-cache --update \
@@ -11,9 +11,8 @@ RUN apk add --no-cache --update \
   build-base \
   musl-dev \
   postgresql-dev \
-  python3 \
-  python3-dev \
-  py3-pip \
+  'python3~=3.7.5' \
+  'python3-dev~=3.7.5' \
   curl \
 # zlib, zlib-dev, and libjpeg-turbo are required by pillow
   zlib \

--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -21,6 +21,5 @@ django-rest-auth = "~=0.9.5"
 django-extensions = "~=2.1.9"
 packaging = "*"
 drf-yasg = "~=1.16.1"
-{% if cookiecutter.is_mobile == "y" %}
+# fcm-django is used for mobile notifications. It can be removed if unneeded.
 fcm-django = "~=0.2.21"
-{% endif %}


### PR DESCRIPTION
alpine:latest is installing python 3.8 which has issues with some packages. For some reason python 3.7.5 isn't available on alpine:latest so I've pinned it to 3.10.

This also replaces the testing repo with community. Gdal has be added to community so testing should no longer be necessary.

I've removed the fcm-django conditional. It breaks dependabot automatic package upgrade PRs. Projects that don't use it can manually remove it. Having it installed shouldn't hurt anything.