### PR TITLE
basename no longer has an underscore

### DIFF
--- a/{{cookiecutter.project_slug}}/home/api/v1/urls.py
+++ b/{{cookiecutter.project_slug}}/home/api/v1/urls.py
@@ -4,8 +4,8 @@ from rest_framework.routers import DefaultRouter
 from home.api.v1.viewsets import SignupViewSet, LoginViewSet, HomePageViewSet, CustomTextViewSet, AppReportView
 
 router = DefaultRouter()
-router.register('signup', SignupViewSet, base_name='signup')
-router.register('login', LoginViewSet, base_name='login')
+router.register('signup', SignupViewSet, basename='signup')
+router.register('login', LoginViewSet, basename='login')
 router.register('customtext', CustomTextViewSet)
 router.register('homepage', HomePageViewSet)
 


### PR DESCRIPTION
Apparently DRF changed this and didn't put it in their changelog.