### PR TITLE
Allow apostrophes in project_name

### DIFF
--- a/{{cookiecutter.project_slug}}/home/management/commands/load_initial_data.py
+++ b/{{cookiecutter.project_slug}}/home/management/commands/load_initial_data.py
@@ -10,14 +10,14 @@ def load_initial_data():
             This is the sample application created and deployed from the crowdbotics slack app. You can
             view list of packages selected for this application below
         </p>"""
-    customtext_title = '{{cookiecutter.project_name}}'
+    customtext_title = "{{cookiecutter.project_name}}"
     CustomText.objects.create(title=customtext_title)
     HomePage.objects.create(body=homepage_body)
 
 
 class Command(BaseCommand):
     can_import_settings = True
-    help = 'Load initial data to db'
+    help = "Load initial data to db"
 
     def handle(self, *args, **options):
         load_initial_data()

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/urls.py
@@ -21,20 +21,20 @@ from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 
 urlpatterns = [
-    path('', include('home.urls')),
-    path('accounts/', include('allauth.urls')),
-    path('api/v1/', include('home.api.v1.urls')),
-    path('admin/', admin.site.urls),
-    path('users/', include('users.urls', namespace='users')),
-    path('rest-auth/', include('rest_auth.urls')),
+    path("", include("home.urls")),
+    path("accounts/", include("allauth.urls")),
+    path("api/v1/", include("home.api.v1.urls")),
+    path("admin/", admin.site.urls),
+    path("users/", include("users.urls", namespace="users")),
+    path("rest-auth/", include("rest_auth.urls")),
     # Override email confirm to use allauth's HTML view instead of rest_auth's API view
-    path('rest-auth/registration/account-confirm-email/<str:key>/', confirm_email),
-    path('rest-auth/registration/', include('rest_auth.registration.urls')),
+    path("rest-auth/registration/account-confirm-email/<str:key>/", confirm_email),
+    path("rest-auth/registration/", include("rest_auth.registration.urls")),
 ]
 
-admin.site.site_header = '{{cookiecutter.project_name}}'
-admin.site.site_title = '{{cookiecutter.project_name}} Admin Portal'
-admin.site.index_title = '{{cookiecutter.project_name}} Admin'
+admin.site.site_header = "{{cookiecutter.project_name}}"
+admin.site.site_title = "{{cookiecutter.project_name}} Admin Portal"
+admin.site.index_title = "{{cookiecutter.project_name}} Admin"
 
 # swagger
 schema_view = get_schema_view(


### PR DESCRIPTION
This updates files that were using single quote strings to double quotes. Projects with an apostrophe in the name were erroring out because of this.

Example error: https://sentry.io/organizations/crowdbotics-corporation/issues/1404728295/?project=1464774&referrer=alert_email