### PR TITLE
PLAT-1921: Update Docker configuration and instructions

### DIFF
--- a/{{cookiecutter.project_slug}}/.dockerignore
+++ b/{{cookiecutter.project_slug}}/.dockerignore
@@ -1,0 +1,1 @@
+postgres-data/

--- a/{{cookiecutter.project_slug}}/.env.example
+++ b/{{cookiecutter.project_slug}}/.env.example
@@ -1,6 +1,6 @@
 DEBUG=1
 HOST=localhost
 PORT=8000
-DATABASE_URL=postgresql://db:5432/<database_name>
+DATABASE_URL=postgres://postgres:<postgres_pwd>@postgres:5432/postgres
 REDIS_URL=redis://redis:6379
 SECRET_KEY=<random_string_goes_here>

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -3,3 +3,4 @@ env/
 .terraform
 .env
 staticfiles/
+postgres-data/

--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,40 +1,24 @@
-FROM alpine:3.10
+FROM ubuntu:bionic
 
-# Add the testing repo in case it's needed for additional dependencies
-# For example, gdal can be installed by using gdal@community
-RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
-
-# Install system dependencies
-RUN apk add --no-cache --update \
-  bash \
-  gcc \
-  build-base \
-  musl-dev \
-  postgresql-dev \
-  'python3~=3.7.5' \
-  'python3-dev~=3.7.5' \
-  curl \
-# zlib, zlib-dev, and libjpeg-turbo are required by pillow
-  zlib \
-  zlib-dev \
-  libjpeg-turbo \
-  libjpeg-turbo-dev
-RUN pip3 install --no-cache-dir -q pipenv
-
-# Add our code
-ADD ./ /opt/webapp/
-WORKDIR /opt/webapp
-
-# Install dependencies
-RUN pipenv install --deploy --system
-
+ENV LANG C.UTF-8
+ARG DEBIAN_FRONTEND=noninteractive
 # Allow SECRET_KEY to be passed via arg so collectstatic can run during build time
 ARG SECRET_KEY
+
+# libpq-dev and python3-dev help with psycopg2
+RUN apt-get update \
+  && apt-get install -y python3.7-dev python3-pip libpq-dev \
+  && apt-get clean all \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/webapp
+COPY . .
+RUN pip3 install --no-cache-dir -q pipenv && pipenv install --deploy --system
 RUN python3 manage.py collectstatic --no-input
 
 # Run the image as a non-root user
-RUN adduser -D myuser
-USER myuser
+RUN adduser --disabled-password --gecos "" django
+USER django
 
 # Run the web server on port $PORT
 CMD waitress-serve --port=$PORT {{cookiecutter.project_slug}}.wsgi:application

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -1,4 +1,4 @@
-# django_scaffold_test
+# {{cookiecutter.project_slug}}
 
 This is a repository for a web application developed with Django, built with [Crowdbotics](https://crowdbotics.com)
 
@@ -26,7 +26,7 @@ This project is set up to run using [Docker Compose](https://docs.docker.com/com
 1. Install Docker
    - Linux - [get.docker.com](https://get.docker.com/)
    - Windows or MacOS - [Docker Desktop](https://www.docker.com/products/docker-desktop)
-1. Clone this repo and `cd django_scaffold_test`
+1. Clone this repo and `cd {{cookiecutter.project_slug}}`
 1. Make sure `Pipfile.lock` exists. If it doesn't, generate it with:
    ```sh
    $ docker run -it --rm -v "$PWD":/django -w /django python:3.7 pip3 install --no-cache-dir -q pipenv && pipenv lock
@@ -60,7 +60,7 @@ This project is set up to run using [Docker Compose](https://docs.docker.com/com
 ### Installation
 
 1. Install [pipenv](https://pypi.org/project/pipenv/)
-2. Clone this repo and `cd django_scaffold_test`
+2. Clone this repo and `cd {{cookiecutter.project_slug}}`
 3. Run `pip install --user --upgrade pipenv` to get the latest pipenv version.
 4. Run `pipenv --python 3.6`
 5. Run `pipenv install`

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -1,30 +1,75 @@
-# {{cookiecutter.project_slug}}
+# django_scaffold_test
+
 This is a repository for a web application developed with Django, built with [Crowdbotics](https://crowdbotics.com)
 
 ### Features
+
 1. **Local Authentication** using email and password with [allauth](https://pypi.org/project/django-allauth/)
 2. **Rest API** using [django rest framework](http://www.django-rest-framework.org/)
 3. **Forgot Password**
-4. Bootstrap4 
+4. Bootstrap4
 5. Toast Notification
-6. Inline content editor in homepage 
+6. Inline content editor in homepage
 
-### Recommended Installation
+# Development
+
+Following are instructions on setting up your development environment.
+
+The recommended way for running the project locally and for development is using Docker.
+
+It's possible to also run the project without Docker.
+
+## Docker Setup (Recommended)
+
+This project is set up to run using [Docker Compose](https://docs.docker.com/compose/) by default. It is the recommended way. You can also use existing Docker Compose files as basis for custom deployment, e.g. [Docker Swarm](https://docs.docker.com/engine/swarm/), [kubernetes](https://kubernetes.io/), etc.
+
+1. Install Docker
+   - Linux - [get.docker.com](https://get.docker.com/)
+   - Windows or MacOS - [Docker Desktop](https://www.docker.com/products/docker-desktop)
+1. Clone this repo and `cd django_scaffold_test`
+1. Make sure `Pipfile.lock` exists. If it doesn't, generate it with:
+   ```sh
+   $ docker run -it --rm -v "$PWD":/django -w /django python:3.7 pip3 install --no-cache-dir -q pipenv && pipenv lock
+   ```
+1. Use `.env.example` to create `.env`
+   ```sh
+   $ cp .env.example .env
+   ```
+1. Update `.env` replacing all `<placeholders>`
+1. Start up the containers
+
+   ```sh
+   $ docker-compose up
+   ```
+
+   This will build the necessary containers and start them, including the web server on the host and port you specified in `.env`.
+
+   Current (project) directroy will be mapped with the container meaning any edits you make will be picked up by the container.
+
+1. Finally, seed the Postgres DB
+   ```sh
+   $ docker-compose exec web python3 manage.py makemigrations
+   $ docker-compose exec web python3 manage.py migrate
+   ```
+
+## Local Setup (Alternative to Docker)
+
 1. [Postgresql](https://www.postgresql.org/download/)
 2. [Python](https://www.python.org/downloads/release/python-365/)
 
 ### Installation
+
 1. Install [pipenv](https://pypi.org/project/pipenv/)
-2. Clone this repo and `cd {{cookiecutter.project_slug}}`
+2. Clone this repo and `cd django_scaffold_test`
 3. Run `pip install --user --upgrade pipenv` to get the latest pipenv version.
 4. Run `pipenv --python 3.6`
 5. Run `pipenv install`
 6. Run `cp .env.example .env`
-7. Update .env file `DATABASE_URL` with your `database_name`, `database_user`, `database_password`, if you use postgresql. 
-    Can alternatively set it to `sqlite:////tmp/my-tmp-sqlite.db`, if you want to use sqlite for local development.
-
+7. Update .env file `DATABASE_URL` with your `database_name`, `database_user`, `database_password`, if you use postgresql.
+   Can alternatively set it to `sqlite:////tmp/my-tmp-sqlite.db`, if you want to use sqlite for local development.
 
 ### Getting Started
+
 1. Run `pipenv shell`
 2. Run `python manage.py makemigrations`
 3. Run `python manage.py migrate`

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -23,7 +23,7 @@ It's possible to also run the project without Docker.
 
 This project is set up to run using [Docker Compose](https://docs.docker.com/compose/) by default. It is the recommended way. You can also use existing Docker Compose files as basis for custom deployment, e.g. [Docker Swarm](https://docs.docker.com/engine/swarm/), [kubernetes](https://kubernetes.io/), etc.
 
-1. Install Docker
+1. Install Docker:
    - Linux - [get.docker.com](https://get.docker.com/)
    - Windows or MacOS - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 1. Clone this repo and `cd {{cookiecutter.project_slug}}`
@@ -31,12 +31,12 @@ This project is set up to run using [Docker Compose](https://docs.docker.com/com
    ```sh
    $ docker run -it --rm -v "$PWD":/django -w /django python:3.7 pip3 install --no-cache-dir -q pipenv && pipenv lock
    ```
-1. Use `.env.example` to create `.env`
+1. Use `.env.example` to create `.env`:
    ```sh
    $ cp .env.example .env
    ```
-1. Update `.env` replacing all `<placeholders>`
-1. Start up the containers
+1. Update `.env` and `docker-compose.override.yml` replacing all `<placeholders>`
+1. Start up the containers:
 
    ```sh
    $ docker-compose up
@@ -46,11 +46,16 @@ This project is set up to run using [Docker Compose](https://docs.docker.com/com
 
    Current (project) directroy will be mapped with the container meaning any edits you make will be picked up by the container.
 
-1. Finally, seed the Postgres DB
+1. Seed the Postgres DB (in a separate terminal):
    ```sh
    $ docker-compose exec web python3 manage.py makemigrations
    $ docker-compose exec web python3 manage.py migrate
    ```
+1. Create a superuser if required:
+   ```sh
+   $ docker-compose exec web python3 manage.py createsuperuser
+   ```
+   You will find an activation link in the server log output.
 
 ## Local Setup (Alternative to Docker)
 

--- a/{{cookiecutter.project_slug}}/docker-compose.override.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.override.yml
@@ -1,0 +1,23 @@
+version: "3"
+
+services:
+  web:
+    build:
+      context: .
+      args:
+        SECRET_KEY: ${SECRET_KEY}
+    env_file: .env
+    volumes:
+      - ./:/opt/webapp
+    ports:
+      - "8000:${PORT}"
+  postgres:
+    environment:
+      POSTGRES_PASSWORD: <postgres_pwd>
+    volumes:
+      - ./postgres-data/postgres:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+  redis:
+    ports:
+      - "6379:6379"

--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -1,19 +1,11 @@
-version: '3'
+version: "3"
+
 services:
   web:
-    build: .
-    ports:
-      - "8000:8000"
-    env_file: .env
     depends_on:
-      - db
-    volumes:
-      - ./:/opt/webapp
-  db:
-    image: postgres:latest
-    ports:
-      - "5432:5432"
+      - postgres
+      - redis
+  postgres:
+    image: postgres:12
   redis:
-    image: redis:alpine
-    ports:
-      - "6379:6379"
+    image: redis:5


### PR DESCRIPTION
## Ticket

PLAT-1921

## Type of PR

- [ ] Bugfix
- [ ] New feature
- [x] Minor changes

## Changes introduced

Some users experienced the limitations of the Alpine platform. Therefore,
it makes sense to switch to an LTS Ubuntu, which is easier to maintain, too.

- Postgres files are mounted to project subdirectory
- Heavy usage of `docker-compose.override.yml`, so it's easier to write
a deployment configuration.
- Users will also benefit from an expanded README including the docker
setup.
- Pinning of the versions in Docker related files will also ensure fewer
unwanted surprises in the future.

## Test and review

1. Make sure you have [Cookiecutter](https://github.com/cookiecutter/cookiecutter) installed, you can [brew](https://brew.sh/) it on MacOS.
1. Clone this branch
1. Then:
    ```sh
    $ cookiecutter django-scaffold
    ```
`cd` into the newly created project and follow instrutions in README.md.