### PR TITLE
Add curl to Dockerfile for streaming logs

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -7,7 +7,7 @@ ARG SECRET_KEY
 
 # libpq-dev and python3-dev help with psycopg2
 RUN apt-get update \
-  && apt-get install -y python3.7-dev python3-pip libpq-dev \
+  && apt-get install -y python3.7-dev python3-pip libpq-dev curl \
   && apt-get clean all \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
curl is required to stream logs to Heroku. Without it we won't get deploy error logs.