### PR TITLE
Pin pipenv to 2018.11.26 since the latest version is broken

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
 
 WORKDIR /opt/webapp
 COPY . .
-RUN pip3 install --no-cache-dir -q pipenv && pipenv install --deploy --system
+RUN pip3 install --no-cache-dir -q 'pipenv==2018.11.26' && pipenv install --deploy --system
 RUN python3 manage.py collectstatic --no-input
 
 # Run the image as a non-root user


### PR DESCRIPTION
pipenv finally released a new version but it's broken in Docker. We need to use the old version until they fix it.