### PR TITLE
add superuser password reset successful message

### DIFF
--- a/{{cookiecutter.project_slug}}/home/management/commands/customchangepassword.py
+++ b/{{cookiecutter.project_slug}}/home/management/commands/customchangepassword.py
@@ -29,5 +29,6 @@ class Command(BaseCommand):
             user = User.objects.get(username=username)
             user.set_password(password)
             user.save()
+            self.stdout.write("Superuser password reset successful.")
         except User.DoesNotExist:
             raise CommandError("User not found with the given username.")


### PR DESCRIPTION
This gives correct message for user with password reset is successful. Also, this will be great help for checking if the password reset is successful while reseting password from dashboard. We can just check for this message instead of current implementation of checking for errors.