### PR TITLE
Pin cryptography package

### DIFF
--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -9,6 +9,7 @@ name = "pypi"
 python_version = "3.7"
 
 [packages]
+cryptography = "<3.4"
 django = "~=2.2.3"
 "boto3" = "~=1.17.3"
 django-environ = "~=0.4.5"


### PR DESCRIPTION
This is needed because the latest version of the cryptography package requires rust to compile, which isn't available.