### PR TITLE
Use dependabot lockfile-only to avoid major updates

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_slug}}/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
       day: sunday
       time: "13:00"
     open-pull-requests-limit: 10
+    # Avoid major upgrades since they may not be compatible with the Crowdbotics ecosystem
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
This setting will only update Pipfile.lock based on Pipfile rules which should prevent major update PRs that could cause issues (eg Django 3).