### PR TITLE
Remove Dependabot schedule.day to allow for more flexible scheduling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,4 @@ updates:
   directory: "/{{cookiecutter.project_slug}}"
   schedule:
     interval: weekly
-    day: sunday
   open-pull-requests-limit: 10


### PR DESCRIPTION
The Dependabot team has requested that we remove all `day` and `time` settings from our config. This will avoid concentrating all runs at the same time and putting undo stress on their infrastructure.