### PR TITLE
PLAT-6799 Update Dockerfile and .dockerignore

### DIFF
--- a/{{cookiecutter.project_slug}}/.dockerignore
+++ b/{{cookiecutter.project_slug}}/.dockerignore
@@ -1,13 +1,75 @@
 postgres-data/
 .env
 *.pyc
-*.mo
 *.db
 *.css.map
-.cache
 .sass-cache
-.idea
 .vagrant
 .git
 .DS_Store
-__pycache__
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Docker
+Dockerfile
+docker-compose.yml
+docker-compose.override.yml
+docker/docker-compose.prod.yml
+
+# JetBrains
+.idea/

--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,35 +1,29 @@
-FROM python:3.8-slim as base
+FROM crowdbotics/cb-django:3.8-slim-buster AS build
 
-# libpq-dev and python3-dev help with psycopg2
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends python3-dev libpq-dev gcc curl \
-  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-  && rm -rf /var/lib/apt/lists/*
-  # You can add additional steps to the build by appending commands down here using the
-  # format `&& <command>`. Remember to add a `\` at the end of LOC 12.
-  # WARNING: Changes to this file may cause unexpected behaviors when building the app.
-  # Change it at your own risk.
+# Copy dependency management files and install app packages to /.venv
+COPY ./Pipfile ./Pipfile.lock /
+RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy
 
 
+FROM crowdbotics/cb-django:3.8-slim-buster AS release
+ARG SECRET_KEY
+
+# Set Working directory
 WORKDIR /opt/webapp
-COPY Pipfile* /opt/webapp/
 
-RUN pip3 install --no-cache-dir -q 'pipenv==2018.11.26' 
-RUN pipenv install --deploy --system
-COPY . /opt/webapp
-
-FROM base as release
-
-COPY --from=base /root/.local /root/.local
-COPY --from=base /opt/webapp/manage.py /opt/webapp/manage.py
-
-
-WORKDIR /opt/webapp
-ENV PATH=/root/.local/bin:$PATH
-ARG SECRET_KEY 
-RUN python3 manage.py collectstatic --no-input
-
-# Run the image as a non-root user
-RUN adduser --disabled-password --gecos "" django
+# Add runtime user with respective access permissions
+RUN groupadd -r django \
+  && useradd -d /opt/webapp -r -g django django \
+  && chown django:django -R /opt/webapp
 USER django
+
+# Copy virtual env from build stage
+COPY --chown=django:django --from=build /.venv /.venv
+ENV PATH="/.venv/bin:$PATH"
+
+# Copy app source
+COPY --chown=django:django . .
+
+# Collect static files and serve app
+RUN python3 manage.py collectstatic --no-input
 CMD waitress-serve --port=$PORT {{cookiecutter.project_slug}}.wsgi:application


### PR DESCRIPTION
## Ticket

[PLAT-6799](https://crowdbotics.atlassian.net/browse/PLAT-6799)
_Related ticket:_ [PLAT-5484](https://crowdbotics.atlassian.net/browse/PLAT-5484)
_Related PR:_ [Update Django Scaffold Docker image](https://github.com/crowdbotics/django-scaffold/pull/342)

## Type of PR

- [ ] Bugfix
- [ ] New feature
- [x] Minor changes

## Changes introduced

Update `Dockerfile` to use a base image created in the `project-deploy/docker/cb-django/Dockerfile` to improve overall build speeds.

## Test and review

_Describe how a reviewer should test your PR_

* Pull the base image `crowdbotics/cb-django:3.8-slim-buster` from dockerhub .
* Checkout the PLAT-6799 branch
* Use `cookiecutter` to create a project from the template and cd into the project source folder
* Run `docker build -t <image-name:tag> --build-arg=SECRET_ENV=<some_super_secret_key> -f Dockerfile  .` 

Once the build succeeds the image should be available when you run `docker images` or `docker image ls`.
