### PR TITLE
Fix get_options dict get call

### DIFF
--- a/{{cookiecutter.project_slug}}/modules/utils.py
+++ b/{{cookiecutter.project_slug}}/modules/utils.py
@@ -9,9 +9,14 @@ GLOBAL_OPTIONS_FILE_PATH = f"{Path.cwd()}/modules/options.json"
 def get_options(module_slug, option_key):
     with open(GLOBAL_OPTIONS_FILE_PATH, "r") as f:
         all_module_options = json.loads(f.read())
-        all_module_options = all_module_options["module_options"]
+        all_module_options = all_module_options.get("module_options", None)
 
-    option_value = all_module_options[module_slug].get(option_key, False)
+    option_value = None
+
+    if all_module_options:
+        module_options = all_module_options.get(model_slug, None)
+        if module_options:
+            option_value = module_options.get(option_key, None)
 
     default_value = getattr(
         importlib.import_module(f"modules.{module_slug}.options"), option_key

--- a/{{cookiecutter.project_slug}}/modules/utils.py
+++ b/{{cookiecutter.project_slug}}/modules/utils.py
@@ -8,16 +8,13 @@ GLOBAL_OPTIONS_FILE_PATH = f"{Path.cwd()}/modules/options.json"
 
 def get_options(module_slug, option_key):
     with open(GLOBAL_OPTIONS_FILE_PATH, "r") as f:
-        module_options = json.loads(f.read())
+        all_module_options = json.loads(f.read())
+        all_module_options = all_module_options["module_options"]
 
-    option_value = [
-        module.get(option_key)
-        for module in module_options["module_options"]
-        if module.get("slug") == module_slug
-    ]
+    option_value = all_module_options[module_slug].get(option_key, False)
 
     default_value = getattr(
         importlib.import_module(f"modules.{module_slug}.options"), option_key
     )
 
-    return option_value[0] if option_value else default_value
+    return option_value if option_value else default_value


### PR DESCRIPTION
This PR fixes `get_options` get call that was looking for a `slug` property, which doesn't exist.