### PR TITLE
remove compare_url from webhook callback

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/webhook_callback.sh
+++ b/{{cookiecutter.project_slug}}/.circleci/webhook_callback.sh
@@ -9,7 +9,6 @@ cat <<EOM
     "repo": "$CIRCLE_REPOSITORY_URL",
     "branch": "$CIRCLE_BRANCH",
     "build_url": "$CIRCLE_BUILD_URL",
-    "compare_url": "$CIRCLE_COMPARE_URL",
     "sha1": "$CIRCLE_SHA1",
     "platform_id": "$PLATFORM_ID",
     "app_url": "$GCP_DEPLOY_ENDPOINT"


### PR DESCRIPTION
CIRCLE_COMPARE_URL env var isn't available from CircleCI version 2.1. So, it's giving error now while webook callback because of that. This will fix it.