### PR TITLE
Update modules.admin

### DIFF
--- a/{{cookiecutter.project_slug}}/modules/admin.py
+++ b/{{cookiecutter.project_slug}}/modules/admin.py
@@ -10,7 +10,7 @@ try:
     admins = Path(".").rglob('admin.py')
 
     for admin in admins:
-        module = import_module(posixpath_to_modulepath(admin))
+        module = import_module(posixpath_to_modulepath(admin), package="modules")
         from module import *  # noqa
 except (ImportError, IndexError):
     pass


### PR DESCRIPTION
- Add "package" argument to import_module to handle errors in some
  setups

In some setups (AWS Lambda), migrations with the current scaffold fail due to importlib complaining about relative imports without a namespace / package.

This is a fix for that. The fix does not interfere with the handling of modules in cb-slack-app.