### PR TITLE
PLAT-9778 Update for rn web deployment with GCP

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/generate_gcp_config.sh
+++ b/{{cookiecutter.project_slug}}/.circleci/generate_gcp_config.sh
@@ -23,7 +23,6 @@ jobs:
       - cloudrun/init
       - cloudrun/build:
           tag: 'gcr.io/${GOOGLE_PROJECT_ID}/${GOOGLE_SERVICE_NAME}'
-          source: "$BACKEND_PATH"
 
       - run:
           name: Run collectstatic and migrations

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
@@ -182,7 +182,7 @@ AUTHENTICATION_BACKENDS = (
 )
 
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
-STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static'){% if cookiecutter.is_mobile == "y" %}, os.path.join(BASE_DIR, 'web_build/static'){% endif %}]
+STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static'){% if cookiecutter.is_mobile == "y" %}, os.path.join(BASE_DIR, 'web_build'){% endif %}]
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 MEDIA_URL = '/mediafiles/'


### PR DESCRIPTION
Ticket: https://crowdbotics.atlassian.net/browse/PLAT-9778

Changes:
Update gcp cloudbuild source as the project root, to use Dockerfile to build rn web while GCP deployment for mobile app.

This should be released along with https://github.com/crowdbotics/modules/pull/798