### PR TITLE
PLAT-9849 Local python packages installation fail on deployment

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -2,6 +2,7 @@ FROM crowdbotics/cb-django:3.8-slim-buster AS build
 
 # Copy dependency management files and install app packages to /.venv
 COPY ./Pipfile ./Pipfile.lock /
+COPY ./modules/ /modules/
 RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy
 
 


### PR DESCRIPTION
## Ticket

PLAT-9829
_Related tickets:_
_Related PRs:_

## Type of PR

- [x] Bugfix
- [ ] New feature
- [ ] Minor changes

## Changes introduced
The `/modules` folder was not copied on the .venv. This leads the Pipenv file to not find the Django module that was installed on the repository -> i.e: _Invalid path ‘./modules/camera’_

## Test and review

- Create an APP
- Add Django module on Studio
-  Deploy the app ( after the Module is installed )
- The deployment should succeed
- You should find the new Module's admin table on the Django Admin Panel of the App.
