### PR TITLE
PLAT-11707-Update AWS_DEFAULT_ACL  env val

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
@@ -241,7 +241,7 @@ USE_S3 = (
 if USE_S3:
     AWS_S3_CUSTOM_DOMAIN = env.str("AWS_S3_CUSTOM_DOMAIN", "")
     AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "max-age=86400"}
-    AWS_DEFAULT_ACL = env.str("AWS_DEFAULT_ACL", "public-read")
+    AWS_DEFAULT_ACL = env.str("AWS_DEFAULT_ACL", "bucket-owner-full-control")
     AWS_MEDIA_LOCATION = env.str("AWS_MEDIA_LOCATION", "media")
     AWS_AUTO_CREATE_BUCKET = env.bool("AWS_AUTO_CREATE_BUCKET", True)
     DEFAULT_FILE_STORAGE = env.str(


### PR DESCRIPTION
##Description of work done

Recent changes in AWS S3 policies to enforce `Bucket owner enforced` for all the newly created S3 buckets are not working with the current `AWS_DEFAULT_ACL` value of `public-read` we enforce. This is resulting in failed object uploads with permissions issues. 

<img width="1145" alt="Screenshot 2023-07-06 at 16 06 36" src="https://github.com/crowdbotics/django-scaffold/assets/13331207/599e1531-2b0f-424d-bf76-2ea1f5a708e6">


## Changes Introduced
- we need to use `bucket-owner-full-control` for the env var `AWS_DEFAULT_ACL` 

#Testing 
##### You can either create a new project and follow the following steps or use an existing app
###### New project
- Create a project
- Deploy API platform
- Add S3 addon form API settings tab
- Deploy API again
- Using the generated app/project code ( in crowdbotics-dev/apps repo ) add ImageField to one of the model (Have to manually create now, the FE doesn’t support this field now) and then add that model to admin.py and push the code.
- Deploy API again
- Create a superuser 
- Log in to the admin panel of the deployed app
- Toggle the environment variable `AWS_DEFAULT_ACL between `public-read` and `bucket-owner-full-control`

###### Existing project

- you can use this app https://dashboard.heroku.com/apps/sam-test-image-41935 
- Every time you change the value, use this test app https://sam-test-image-41935-2f80a23f656d.herokuapp.com/admin/home/image/add/ to upload images and check which one works.
- `bucket-owner-full-control` is supposed to work while `public-read` gives 503 errors.