### PR TITLE
Add DEFAULT_FROM_EMAIL to settings.py

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
@@ -224,6 +224,10 @@ EMAIL_HOST_PASSWORD = env.str("SENDGRID_PASSWORD", "")
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 
+DEFAULT_FROM_EMAIL = env.str(
+    "DEFAULT_FROM_EMAIL", "{{cookiecutter.project_name}} Support <support@{{cookiecutter.custom_domain}}>"
+)
+
 
 # AWS S3 config
 AWS_ACCESS_KEY_ID = env.str("AWS_ACCESS_KEY_ID", "")


### PR DESCRIPTION
chore(settings.py): add DEFAULT_FROM_EMAIL configuration to set the default sender email address for the application's emails