### PR TITLE
Fix: Azure deployment

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/generate_azure_config.sh
+++ b/{{cookiecutter.project_slug}}/.circleci/generate_azure_config.sh
@@ -18,7 +18,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.7
+          version: default
           docker_layer_caching: true
       - run:
           name: Install Azure CLI


### PR DESCRIPTION
Update `setup_remote_docker` version to `default`. This takes in the latest supported version. 

I have tested with this update, it works.