### PR TITLE
PI-465: Add CSRF_TRUSTED_ORIGINS setting to enhance security and fix the 403 error on the Admin page

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
@@ -68,6 +68,8 @@ SECRET_KEY = env.str("SECRET_KEY")
 ALLOWED_HOSTS = env.list("HOST", default=["*"])
 SITE_ID = 1
 
+CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])
+
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 SECURE_SSL_REDIRECT = env.bool("SECURE_REDIRECT", default=False)
 


### PR DESCRIPTION
[Jira Ticket:](https://crowdbotics.atlassian.net/browse/PI-465)

This change allows the application to specify trusted origins for CSRF protection, improving the overall security of the application.